### PR TITLE
Fixed punctuation and added clarity to cloning instruction Update CON…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Never made an open-source contribution before? Wondering how contributions work 
 
 - Fork the repository associated with the issue to your local GitHub organization. This means that you will have a copy of the repository under `your-GitHub-username/repository-name`.
 
-- Clone the forked repository to your local machine using `git clone https://github.com/github-username/repository-name.git`. E.g. for a repo named "xyzRepo", the user can run https://github.com/github-username/xyzRepo.git.
+- Clone the forked repository to your local machine using `git clone https://github.com/github-username/repository-name.git`. E.g., for a repo named "xyzRepo", the user can run `git clone https://github.com/github-username/xyzRepo.git`.
 
 - Create a new branch for your fix using `git checkout -b branch-name-here`. E.g `git checkout -b main`
 


### PR DESCRIPTION
**Description:**  
In the "How do I make a contribution?" section, there was a small mistake in the example command. Specifically, after "E.g." there was a missing comma, which is needed in proper English usage. Additionally, the instruction to clone a repository was incomplete, showing only the URL without indicating the proper `git clone` command. 

Here’s the change:
- Corrected the punctuation by adding a comma after "E.g."
- Updated the cloning example to show the full command: `git clone https://github.com/github-username/xyzRepo.git`, ensuring clarity in the instructions.

This small correction ensures the guide is both grammatically correct and clear for users following the instructions.