### PR TITLE
 Fix Typo in Section Names and Remove Duplicate Attributes

### DIFF
--- a/.github/ISSUE_TEMPLATE/code_mistake.yml
+++ b/.github/ISSUE_TEMPLATE/code_mistake.yml
@@ -26,7 +26,7 @@ body:
         - Section 10 | ERC20s
         - Section 11 | NFTs
         - Section 12 | Stablecoin
-        - Section 13 | Merkle Tress
+        - Section 13 | Merkle Trees
         - Section 14 | Upgrades
         - Section 15 | Account Abstraction
         - Section 16 | DAOs

--- a/.github/ISSUE_TEMPLATE/video_mistake.yml
+++ b/.github/ISSUE_TEMPLATE/video_mistake.yml
@@ -36,7 +36,6 @@ body:
       required: true
   - type: input
     attributes:
-    attributes:
       label: Could you please leave a link to the Cyfrin Updraft Lesson (or YouTube video timestamp) where this error occurs? (You can right click a video and "copy video URL at current time")
       placeholder: "https://updraft.cyfrin.io/courses/foundry/foundry-simple-storage/introduction-foundry-simple-storage?lesson_format=video"
   - type: textarea


### PR DESCRIPTION


## Changes Made:

### 1. In `.github/ISSUE_TEMPLATE/code_mistake.yml`:
- Changed `"Section 13 | Merkle Tress"` to `"Section 13 | Merkle Trees"`
- **Reason**: Fixed a spelling error in the section name. "Tress" was incorrectly used instead of "Trees", which is the correct term for the data structure being referenced (Merkle Trees).

### 2. In `.github/ISSUE_TEMPLATE/video_mistake.yml`:
- Removed duplicate `attributes:` line in the input section
- **Reason**: The duplicate `attributes` declaration was a syntax error in the YAML file that could cause parsing issues. YAML requires unique keys at the same level.

