### PR TITLE
 Grammar and Style Fixes

### DIFF
--- a/chronological-updates.md
+++ b/chronological-updates.md
@@ -19,7 +19,7 @@ For those who prefer the video format here we have a video with a recompilation 
 
 ## Lesson 4 Challenge
 
-We are not going to spoil you the solution of most the challenges but when is our fault we have to acknowledge it. In this challenge we made a little mistake on the smart contract, in line 40 there is a typo stating `10e10` instead of `1e10` which is the correct value. This is the reason why the challenge is not working as expected.
+We are not going to spoil you the solution of most the challenges but when it is our fault we have to acknowledge it. In this challenge we made a little mistake on the smart contract, in line 40 there is a typo stating `10e10` instead of `1e10` which is the correct value. This is the reason why the challenge is not working as expected.
 
 ```solidity
 function solveChallenge(uint256 priceGuess, string memory yourTwitterHandle) external {

--- a/how-to-answer-a-question.md
+++ b/how-to-answer-a-question.md
@@ -12,7 +12,7 @@ Thank you for wanting to answer questions! This is how we grow as a community :)
 
 * If the question is poorly formatted and you know how to reformat it reformat it and ask them next time to format their code.
 
-* If the question is posted in the wrong place (like a theoretical question posted on stackoverflow) kindly let them know that it's in the wrong place. 
+* If the question is posted in the wrong place (like a theoretical question posted on Stack Overflow) kindly let them know that it's in the wrong place. 
  
 * If the question has already been asked and answered, answer with a link to the question that has already been asked and answered and ask if that solves the problem.
  
@@ -24,7 +24,7 @@ Thank you for wanting to answer questions! This is how we grow as a community :)
 
 ### Don't feel obliged to help right away if they are not asking well-formatted questions. Make them ask a well-formatted question first before you answer!
 
-But don't be a jerk about it. If they just need a little formatting touch up, just touch up their question for them. 
+But don't be a jerk about it. If they just need a little formatting touch-up, just touch-up their question for them. 
 
 # 2. Make sure your answer unblocks them
 


### PR DESCRIPTION

## File Changed
`how-to-answer-a-question.md`

## Changes Made

1. `stackoverflow` → `Stack Overflow`
   - Reason: "Stack Overflow" is a proper noun and should be capitalized according to the official brand name.

2. `formatting touch up` → `formatting touch-up`
   - Reason: When used as a compound modifier, "touch-up" should be hyphenated according to standard English grammar rules.

