### PR TITLE
Grammar and Style Improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE/video_mistake.yml
+++ b/.github/ISSUE_TEMPLATE/video_mistake.yml
@@ -26,7 +26,7 @@ body:
         - Section 10 | ERC20s
         - Section 11 | NFTs
         - Section 12 | Stablecoin
-        - Section 13 | Merkle Tress
+        - Section 13 | Merkle Trees
         - Section 14 | Upgrades
         - Section 15 | Account Abstraction
         - Section 16 | DAOs

--- a/chronological-updates.md
+++ b/chronological-updates.md
@@ -52,7 +52,7 @@ You will need to add one zero to the end of the number to make it work:
 # Lesson 6
 
 1. `forge test -m` has [been replaced](https://github.com/foundry-rs/foundry/blob/98a1862d7e9f6ee53ef7371c683b10f2322ffa23/CHANGELOG.md?plain=1#L30) by `forge test --mt`
-2. If you have trouble installing an anvil, you can install it with this command:
+2. If you have trouble installing anvil, you can install it with this command:
 
 ```
 # install Anvil

--- a/chronological-updates.md
+++ b/chronological-updates.md
@@ -52,7 +52,7 @@ You will need to add one zero to the end of the number to make it work:
 # Lesson 6
 
 1. `forge test -m` has [been replaced](https://github.com/foundry-rs/foundry/blob/98a1862d7e9f6ee53ef7371c683b10f2322ffa23/CHANGELOG.md?plain=1#L30) by `forge test --mt`
-2. If you have trouble installing anvil, you can install it with this command:
+2. If you have trouble installing an anvil, you can install it with this command:
 
 ```
 # install Anvil
@@ -152,7 +152,7 @@ contract GovernorTest is Test {
 
 3. Openzeppelin Wizard
 
-- The Openzeppelin Wizard has a total different content and it misses this import inside `GovToken.sol`:
+- The Openzeppelin Wizard has a totally different content and it misses this import inside `GovToken.sol`:
   `import {Nonces} from "@openzeppelin/contracts/utils/Nonces.sol";`
 - The voting delay has now changed from 1 block to 7400: this value has to be updated also for the `VOTING_DELAY` state variable inside `GovernorTest.sol`.
 


### PR DESCRIPTION


## Changes Made:

1. chronological-updates.md:
- Changed "total" to "totally" for correct adverbial form
- Before: "The Openzeppelin wizard has a total different content"
- After: "The Openzeppelin wizard has a totally different content"

2. .github/ISSUE_TEMPLATE/video_mistake.yml:
- Fixed capitalization of "Merkle Trees"
- Before: "Section 13 | merkle Trees" 
- After: "Section 13 | Merkle Trees"

