### PR TITLE
Fixed grammatical issues in documentation

### DIFF
--- a/content-updates.md
+++ b/content-updates.md
@@ -50,7 +50,7 @@ Bots, bots, bots! Let's figure out what they're all about and how you can outwit
 
 8️⃣ "The Must-Read Web3 Books: Get Your Read On!" 📚
 
-Calling all book nerds! We're gonna dish on the books you can't afford to miss if you're serious about Web3. Might even chat with a few authors, who's knows?
+Calling all book nerds! We're gonna dish on the books you can't afford to miss if you're serious about Web3. Might even chat with a few authors, who knows?
 
 9️⃣ "Mastering In-line Assembly and Yul" 🤖
 

--- a/content-updates.md
+++ b/content-updates.md
@@ -50,7 +50,7 @@ Bots, bots, bots! Let's figure out what they're all about and how you can outwit
 
 8️⃣ "The Must-Read Web3 Books: Get Your Read On!" 📚
 
-Calling all book nerds! We're gonna dish on the books you can't afford to miss if you're serious about Web3. Might even chat with a few authors, who knows?
+Calling all book nerds! We're gonna dish on the books you can't afford to miss if you're serious about Web3. Might even chat with a few authors, who's knows?
 
 9️⃣ "Mastering In-line Assembly and Yul" 🤖
 

--- a/how-to-answer-a-question.md
+++ b/how-to-answer-a-question.md
@@ -30,7 +30,7 @@ But don't be a jerk about it. If they just need a little formatting touch-up, ju
 
 * Often times, people will ask questions where the answer might be X, but they are trying to do Y. Try to anticipate what people are trying to do. Answer the question at face value, and then maybe give more information on where to go next. 
 
-* Often, giving a summary of your answer at the top with copy pasteable code, and then a "more information" is a best practice. 
+* Often, giving a summary of your answer at the top with copy-pasteable code, and then a "more information" is a best practice. 
 
 # 3. Remember this is living documentation!
 


### PR DESCRIPTION


1. content-updates.md:
- Old: "who knows?"
- New: "who's knows?"
Reason: Added apostrophe for "who is" contraction

2. how-to-answer-a-question.md:
- Old: "copy pasteable"
- New: "copy-pasteable" 
Reason: Added hyphen for proper compound adjective

Files modified:
- content-updates.md
- how-to-answer-a-question.md