### PR TITLE
Grammar and Clarity Fixes

### DIFF
--- a/how-to-answer-a-question.md
+++ b/how-to-answer-a-question.md
@@ -16,7 +16,7 @@ Thank you for wanting to answer questions! This is how we grow as a community :)
  
 * If the question has already been asked and answered, answer with a link to the question that has already been asked and answered and ask if that solves the problem.
  
-* If the problem has a poor title, doesn't make sense to others, etc, feel free to edit the question to what does if you can understand it. If not, you can answer by saying "I don't quite understand what you're asking, could you reformat your question following the "how to ask a question" guide? 
+* If the problem has a poor title, doesn't make sense to others, etc, feel free to edit the question to what it does if you can understand it. If not, you can answer by saying "I don't quite understand what you're asking, could you reformat your question following the "how to ask a question" guide? 
  
 * If they used screenshots, feel free to ask them to copy-paste the code. 
  
@@ -24,7 +24,7 @@ Thank you for wanting to answer questions! This is how we grow as a community :)
 
 ### Don't feel obliged to help right away if they are not asking well-formatted questions. Make them ask a well-formatted question first before you answer!
 
-But don't be a jerk about it. If they just need a little formatting touch-up, just touch-up their question for them. 
+But don't be a jerk about it. If they just need a little formatting touch up, just touch up their question for them. 
 
 # 2. Make sure your answer unblocks them
 

--- a/read-before-deploying-serious-projects-to-zksync.md
+++ b/read-before-deploying-serious-projects-to-zksync.md
@@ -41,7 +41,7 @@ Github Issues:
 - Not a GitHub issue, but this package should be clearer: https://www.npmjs.com/package/@matterlabs/zksync-contracts
 
 ## Rationale
-The current [zksync-contracts](https://www.npmjs.com/package/@matterlabs/zksync-contracts) npm packages is currently recommended in the ZKsync documentation, however it's very unclear what code it is using and how to contribute. At the moment, this lack of clarity could be considered a security issue, as the code was published a year ago and the ZKsync chain has changed a lot since then. In the future, the [era-contracts](https://github.com/matter-labs/era-contracts) should replace it
+The current [zksync-contracts](https://www.npmjs.com/package/@matterlabs/zksync-contracts) npm packages are currently recommended in the ZKsync documentation, however it's very unclear what code it is using and how to contribute. At the moment, this lack of clarity could be considered a security issue, as the code was published a year ago and the ZKsync chain has changed a lot since then. In the future, the [era-contracts](https://github.com/matter-labs/era-contracts) should replace it
 
 # 5. Using 5.0.0+ of openzeppelin libraries and hardhat 
 - [ ] The dependency on specific openzeppelin packages should be removed for zksync libraries.


### PR DESCRIPTION
Fixed singular/plural agreement:

Old: npm packages is currently recommended...
New: npm packages are currently recommended...
Reason: "Packages" is plural, so "is" → "are."
Corrected hyphenation in "touch up":

Old: just touch-up their question
New: just touch up their question
Reason: "Touch-up" (hyphenated) is a noun, but here it's a verb.
Fixed unclear phrasing:

Old: edit the question to what does if you can understand it.
New: edit the question to what it does if you can understand it.
Reason: Added "it" for grammatical correctness.