### PR TITLE
Fix Assembly Storage & Retrieval

### DIFF
--- a/ai-prompting-f23/ai-prompt-it-gets-wrongish.md
+++ b/ai-prompting-f23/ai-prompt-it-gets-wrongish.md
@@ -10,14 +10,14 @@ contract AINotHelpful {
 
     function assemblyStore(uint256 newNumber) external {
         assembly {
-            sstore(0x00, newNumber)
+            sstore(myNumberOne.slot, newNumber)
         }
     }
 
     function assemblyView() external view returns (uint256) {
         assembly {
             mstore(0, result)
-            return(0, 0x20)
+            return(myNumberOne.slot, 0x20)
         }
     }
 }


### PR DESCRIPTION
Fixed Storage in assemblyStore

Before: sstore(0x00, newNumber)
After: sstore(myNumberOne.slot, newNumber)
Reason: Ensures correct storage slot usage.