### PR TITLE
[Edit] : Add instructions to link a an empty repository to Remix IDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,6 +709,7 @@ The Blockchain Basics has it's own [GitHub repository (aka, codebase)](https://g
 _[⭐️ Welcome to Remix - Simple Storage](https://updraft.cyfrin.io/courses/solidity/simple-storage/welcome-to-solidity-fundamentals?lesson_format=video)_
 
 - [Remix](https://remix.ethereum.org/)
+  - Remix now has the ability to link your workpace with your github repository. The icon is below the search icon on the left side bar (the second icon). This process involves authenticating against an EMPTY repository and setting up the git remote. After completing this process, you can push all your work directly from remix to your repo.
 - [Solidity Documentation](https://docs.soliditylang.org/en/latest/index.html)
 
 ## Setting Up Your First Contract


### PR DESCRIPTION
# What ? 

1. Remix allow you to link your workspace with an empty repository so that you can push the work directly from the workspace to the empty git repo. 
2.  Only written instruction given , a gif demo of this process is not attached, or could be? 

