### PR TITLE
 Fix broken YouTube link preview

### DIFF
--- a/chronological-updates.md
+++ b/chronological-updates.md
@@ -4,7 +4,7 @@
 
 For those who prefer the video format here we have a video with a recompilation of these updates you can follow along:
 
-[![Chronological Updates](https://img.youtube.com/vi/G_evB-LLkRU/0.jpg)](https://www.youtube.com/watch?v=G_evB-LLkRU)
+[![Chronological Updates](https://img.youtube.com/vi/G_evB-LLkRU/0.jpg)]()
 
 # Lesson 0
 

--- a/chronological-updates.md
+++ b/chronological-updates.md
@@ -2,7 +2,6 @@
 
 *For moving forward, updates will now be on respective videos in Cyfrin Updraft. This file will no longer be updated.*
 
-For those who prefer the video format here we have a video with a recompilation of these updates you can follow along:
 
 
 # Lesson 0

--- a/chronological-updates.md
+++ b/chronological-updates.md
@@ -4,7 +4,6 @@
 
 For those who prefer the video format here we have a video with a recompilation of these updates you can follow along:
 
-[![Chronological Updates](https://img.youtube.com/vi/G_evB-LLkRU/0.jpg)]()
 
 # Lesson 0
 


### PR DESCRIPTION
Found a broken video link thumbnail in chronological-updates.md. The embedded YouTube thumbnail is present, but the actual video link (https://www.youtube.com/watch?v=G_evB-LLkRU) appears to be unavailable or leads to a removed/private video.

✅ Suggested Fix:
Either:

Replace the broken link with a valid working YouTube video link, or

Remove the thumbnail embed altogether to avoid confusion for readers

❗ Currently, the link redirects to a non-working or private page.

Let me know if there’s an updated or valid link I can substitute in its place!

