### PR TITLE
fix(readme): update LICENSE URL path

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [issues-shield]: https://img.shields.io/github/issues/cyfrin/foundry-full-course-cu.svg?style=for-the-badge
 [issues-url]: https://github.com/cyfrin/foundry-full-course-cu/issues
 [license-shield]: https://img.shields.io/github/license/cyfrin/foundry-full-course-cu.svg?style=for-the-badge
-[license-url]: https://github.com/cyfrin/foundry-full-course-cu/blob/master/LICENSE.txt
+[license-url]: https://github.com/Cyfrin/foundry-full-course-cu/blob/main/LICENSE
 [linkedin-shield]: https://img.shields.io/badge/-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&colorB=555
 
 _Entire course and video content updated June 15, 2024_


### PR DESCRIPTION
The previous URL pointed to a non-existent file (LICENSE.txt) in the outdated master branch.
The new URL correctly links to the LICENSE file in the main branch, fixing a 404 error for users looking for the license.