### PR TITLE
docs: Update README to remove unsupported `--no-commit` flag for Foundry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1650,7 +1650,7 @@ _[⌨️ Implementing Chainlink VRF - Introduction ](https://updraft.cyfrin.io/c
 * [Chainlink Brownie Contracts](https://github.com/smartcontractkit/chainlink-brownie-contracts)
 
 ```bash
-forge install smartcontractkit/chainlink-brownie-contracts@1.1.1 --no-commit
+forge install smartcontractkit/chainlink-brownie-contracts@1.1.1 
 ```
 
 ## Modulo


### PR DESCRIPTION
## Description
This PR updates the Foundry commands in the `README.md` file by removing the `--no-commit` flag.

## Why is this change necessary?
In recent updates to Foundry, the `--no-commit` behavior has become the default. Passing the `--no-commit` flag explicitly now throws an error, which prevents users from running the setup commands successfully. 

## Changes Made
- Removed the `--no-commit` flag from the installation/setup instructions in the README to ensure compatibility with the latest version of Foundry.