### PR TITLE
docs: add hyperlink to discussions in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,4 +32,4 @@ Never made an open-source contribution before? Wondering how contributions work 
 
 # Where can I go for help?
 
-If you need help, you can ask questions on our **discussions** tab.
+If you need help, you can ask questions on our **[discussions](https://github.com/Cyfrin/foundry-full-course-cu/discussions)** tab.


### PR DESCRIPTION
## Description
Added a hyperlink to the "discussions" word in the CONTRIBUTING.md file to improve user navigation and experience.

## Changes Made
- Added clickable hyperlink to discussions tab in the "Where can I go for help?" section
- Link directs users to: https://github.com/Cyfrin/foundry-full-course-cu/discussions
- Maintains clean, minimal design (only "discussions" is linked, not "tab")

## Why?
- Reduces friction for new contributors seeking help
- Direct navigation improves user experience
- Professional and accessible approach
- Encourages community engagement through discussions

## Type of Change
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing
N/A - Documentation change only

## Screenshots

<img width="532" height="404" alt="Screenshot from 2026-06-25 16-49-23" src="https://github.com/user-attachments/assets/5e79fc5f-eeed-423d-b62f-86ebc3c415c8" />
